### PR TITLE
Formatting fixes and minor updates

### DIFF
--- a/docs/basics/using-apps.md
+++ b/docs/basics/using-apps.md
@@ -2,7 +2,7 @@
 
 Note: This is currently not supported in Zero Install for Windows. Please see [Desktop integration](windows.md) for a functionally similar replacement.
 
-Apps (introduced in 0install 1.9) work a bit like aliases, e.g.
+Apps allow you to create command-line launchers:
 
 ```shell
 $ 0install add rox http://rox.sourceforge.net/2005/interfaces/ROX-Filer
@@ -10,18 +10,7 @@ $ rox --version
 ROX-Filer 2.11
 ```
 
-The main difference is that apps store their current selections (in `~/.config/0install.net/apps/rox/selections.xml` in this case). This means that they start faster, because the solver isn't needed:
-
-```shell
-$ 0alias rox-alias http://rox.sourceforge.net/2005/interfaces/ROX-Filer
-$ 0install add rox-app http://rox.sourceforge.net/2005/interfaces/ROX-Filer
-
-$ time rox-alias --version > /dev/null
-rox-alias --version > /dev/null  0.12s user 0.02s system 91% cpu 0.144 total
-
-$ time rox-app --version > /dev/null
-rox-app --version > /dev/null  0.06s user 0.02s system 92% cpu 0.082 total
-```
+Apps store their current selections (in `~/.config/0install.net/apps/rox/selections.xml` in this case). This means that they start slightly faster than using `0install run URI`, because the solver isn't needed.
 
 When run, they still trigger a background update if they haven't been updated for a while, and you can also update them manually:
 
@@ -30,7 +19,7 @@ $ 0install update rox
 No updates found. Continuing with version 2.11.
 ```
 
-They also remember any restrictions (e.g. --before).
+They also remember any restrictions (e.g. `--before`).
 
 Each app also stores past selections (max one set per day) so if an update goes wrong you can see what changed and roll-back easily:
 
@@ -49,5 +38,3 @@ To run using the previous selections, use:
 ```shell
 $ 0install run /home/tal/.config/0install.net/apps/0publish/selections-2012-06-16.xml
 ```
-
-Starting with 0install 1.14, `0alias` is deprecated, and trying to add an alias will add an app instead.

--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -306,7 +306,7 @@ Update: Nix is planning to use binary hashes everywhere in future (zeroing out s
 
 Another difference between Nix and Zero Install is that Nix treats configurations as packages. Changing your configuration is like "upgrading" your configuration package to a new version. Rolling back a change is like reverting to a previous version. Zero Install doesn't generally handle configuration settings, preferring to let the user use subversion (or similar) for that, but it's an interesting idea.
 
-Building a Nix package involves creating a "Nix expression" in a (custom) functional language. The expression fills the same role as a Zero Install source feedit says where to download the source, what its digest is, what the build dependencies are, and how to build it.
+Building a Nix package involves creating a "Nix expression" in a (custom) functional language. The expression fills the same role as a Zero Install source feed: it says where to download the source, what its digest is, what the build dependencies are, and how to build it.
 
 While Zero Install is mainly targeted at adding additional packages to an existing system, Nix aims to manage the whole system (although it installs cleanly alongside your existing package manager). Nix packages have short names (like `perl`) not full URIs, and thus it appears to assume a centrally-controlled repository.
 

--- a/docs/details/cli.md
+++ b/docs/details/cli.md
@@ -297,12 +297,12 @@ On Windows you can also use <code>0install-win</code> instead. This will display
 <tr>
   <td><nobr><code>--os <code>OS</code></code></nobr></td>
   <td>Forces the solver to target the operating system <code>OS</code>.
-<br/>Supported values: *, POSIX, Linux, Solaris, FreeBSD, Darwin, MacOSX, Cygwin, Windows, unknown</td>
+<br/>Supported values: \*, POSIX, Linux, Solaris, FreeBSD, Darwin, MacOSX, Cygwin, Windows, unknown</td>
 </tr>
 <tr>
   <td><nobr><code>--cpu <code>CPU</code></code></nobr></td>
   <td>Forces the solver to target a specific <code>CPU</code>.
-<br/>Supported values: *, i386, i486, i586, i686, x86_64, ppc, ppc64, armv6l, armv7l, src, unknown</td>
+<br/>Supported values: \*, i386, i486, i586, i686, x86_64, ppc, ppc64, armv6l, armv7l, src, unknown</td>
 </tr>
 <tr>
   <td><nobr><code>--language</code></nobr></td>
@@ -388,12 +388,12 @@ On Windows you can also use <code>0install-win</code> instead. This will display
 <tr>
   <td><nobr><code>--os <code>OS</code></code></nobr></td>
   <td>Forces the solver to target the operating system <code>OS</code>.
-<br/>Supported values: *, POSIX, Linux, Solaris, FreeBSD, Darwin, MacOSX, Cygwin, Windows, unknown</td>
+<br/>Supported values: \*, POSIX, Linux, Solaris, FreeBSD, Darwin, MacOSX, Cygwin, Windows, unknown</td>
 </tr>
 <tr>
   <td><nobr><code>--cpu <code>CPU</code></code></nobr></td>
   <td>Forces the solver to target a specific <code>CPU</code>.
-<br/>Supported values: *, i386, i486, i586, i686, x86_64, ppc, ppc64, armv6l, armv7l, src, unknown</td>
+<br/>Supported values: \*, i386, i486, i586, i686, x86_64, ppc, ppc64, armv6l, armv7l, src, unknown</td>
 </tr>
 <tr>
   <td><nobr><code>--language</code></nobr></td>
@@ -483,12 +483,12 @@ On Windows you can also use <code>0install-win</code> instead. This will display
 <tr>
   <td><nobr><code>--os <code>OS</code></code></nobr></td>
   <td>Forces the solver to target the operating system <code>OS</code>.
-<br/>Supported values: *, POSIX, Linux, Solaris, FreeBSD, Darwin, MacOSX, Cygwin, Windows, unknown</td>
+<br/>Supported values: \*, POSIX, Linux, Solaris, FreeBSD, Darwin, MacOSX, Cygwin, Windows, unknown</td>
 </tr>
 <tr>
   <td><nobr><code>--cpu <code>CPU</code></code></nobr></td>
   <td>Forces the solver to target a specific <code>CPU</code>.
-<br/>Supported values: *, i386, i486, i586, i686, x86_64, ppc, ppc64, armv6l, armv7l, src, unknown</td>
+<br/>Supported values: \*, i386, i486, i586, i686, x86_64, ppc, ppc64, armv6l, armv7l, src, unknown</td>
 </tr>
 <tr>
   <td><nobr><code>--language</code></nobr></td>
@@ -578,12 +578,12 @@ On Windows you can also use <code>0install-win</code> instead. This will display
 <tr>
   <td><nobr><code>--os <code>OS</code></code></nobr></td>
   <td>Forces the solver to target the operating system <code>OS</code>.
-<br/>Supported values: *, POSIX, Linux, Solaris, FreeBSD, Darwin, MacOSX, Cygwin, Windows, unknown</td>
+<br/>Supported values: \*, POSIX, Linux, Solaris, FreeBSD, Darwin, MacOSX, Cygwin, Windows, unknown</td>
 </tr>
 <tr>
   <td><nobr><code>--cpu <code>CPU</code></code></nobr></td>
   <td>Forces the solver to target a specific <code>CPU</code>.
-<br/>Supported values: *, i386, i486, i586, i686, x86_64, ppc, ppc64, armv6l, armv7l, src, unknown</td>
+<br/>Supported values: \*, i386, i486, i586, i686, x86_64, ppc, ppc64, armv6l, armv7l, src, unknown</td>
 </tr>
 <tr>
   <td><nobr><code>--language</code></nobr></td>
@@ -713,12 +713,12 @@ On Windows you can also use <code>0install-win</code> instead. This will display
 <tr>
   <td><nobr><code>--os <code>OS</code></code></nobr></td>
   <td>Forces the solver to target the operating system <code>OS</code>.
-<br/>Supported values: *, POSIX, Linux, Solaris, FreeBSD, Darwin, MacOSX, Cygwin, Windows, unknown</td>
+<br/>Supported values: \*, POSIX, Linux, Solaris, FreeBSD, Darwin, MacOSX, Cygwin, Windows, unknown</td>
 </tr>
 <tr>
   <td><nobr><code>--cpu <code>CPU</code></code></nobr></td>
   <td>Forces the solver to target a specific <code>CPU</code>.
-<br/>Supported values: *, i386, i486, i586, i686, x86_64, ppc, ppc64, armv6l, armv7l, src, unknown</td>
+<br/>Supported values: \*, i386, i486, i586, i686, x86_64, ppc, ppc64, armv6l, armv7l, src, unknown</td>
 </tr>
 <tr>
   <td><nobr><code>--language</code></nobr></td>
@@ -1393,7 +1393,7 @@ On Windows you can also use <code>0install-win</code> instead. This will display
 </tr>
 </table>
 <a name='store_verify'></a><h1>store verify</h1>
-<p>Makes sure an implementation has not been damaged (i.e. it manifest digest has not changed).</p>
+<p>Makes sure an implementation has not been damaged (i.e. if manifest digest has not changed).</p>
 <p><b>Usage:</b> <code>0install store verify [DIRECTORY] DIGEST</code></p>
 <table>
 <tr>
@@ -2076,12 +2076,12 @@ On Windows you can also use <code>0install-win</code> instead. This will display
 <tr>
   <td><nobr><code>--os <code>OS</code></code></nobr></td>
   <td>Forces the solver to target the operating system <code>OS</code>.
-<br/>Supported values: *, POSIX, Linux, Solaris, FreeBSD, Darwin, MacOSX, Cygwin, Windows, unknown</td>
+<br/>Supported values: \*, POSIX, Linux, Solaris, FreeBSD, Darwin, MacOSX, Cygwin, Windows, unknown</td>
 </tr>
 <tr>
   <td><nobr><code>--cpu <code>CPU</code></code></nobr></td>
   <td>Forces the solver to target a specific <code>CPU</code>.
-<br/>Supported values: *, i386, i486, i586, i686, x86_64, ppc, ppc64, armv6l, armv7l, src, unknown</td>
+<br/>Supported values: \*, i386, i486, i586, i686, x86_64, ppc, ppc64, armv6l, armv7l, src, unknown</td>
 </tr>
 <tr>
   <td><nobr><code>--language</code></nobr></td>

--- a/docs/details/security.md
+++ b/docs/details/security.md
@@ -36,8 +36,8 @@ It's also important to separate out two aspects of installation that are easily 
 
 | Privileges granted | Only root can install things   | Anyone can install things   |
 |--------------------|--------------------------------|-----------------------------|
-| Full access        | Default apt-get                | apt-get with modified rules |
-| No access          | Zero Install with restrictions | Default Zero Install        |
+| **Full access**    | Default apt-get                | apt-get with modified rules |
+| **No access**      | Zero Install with restrictions | Default Zero Install        |
 
 A typical package manager only allows root (or an administrator) to install software by default, and grants that software full access to the machine, including access to all user accounts. You can change the rules to allow others to install software (e.g. using PolicyKit or sudoers, you might allow anyone to upgrade a package), but the software still gets complete access to the machine.
 
@@ -53,7 +53,7 @@ Some people think of security and usability as a trade-off, with systems being e
 
 - Sometimes, I forget where I saved a file. But, I never need to search `/usr` in case I accidentally saved my letter there; it can't be there, because my word processor doesn't have permission to save there.
 
-- Windows users (so I hear) often find their computers are infected with spyware and adware, which slows them down, causes crashes, and redirects them to undesirable web sites. Such a system has poor usability.
+- People often find their computers are infected with spyware and adware, which slows them down, causes crashes, and redirects them to undesirable web sites. Such a system has poor usability.
 
 - An artist may find a useful image processing filter on the web. If all this filter can do is read an input image and output a modified one then the artist is more likely to try it (and produce better work). If image filters can seriously damage the system then the artist may have to pass it over; the risk from a malicious filter is too great.
 
@@ -112,7 +112,7 @@ To perform the second attack, the attacker needs to replace a trusted feed file 
 - Break into the developer's private machine, get their private GPG key, install a keystroke logger, and get the GPG pass-phrase. Then break into the web server and install a compromised signed feed.
 - Break into the webserver and install a feed signed with their own key (a new key with a new fingerprint, but claiming to belong to the original author), and trick users into accepting it.
 
-The second option is probably easiest. Zero Install currently warns users if they run software signed with an unknown GPG key (we maintain a default database of known keys, but we do not have the resources to verify the owners of the keys). Note that even if a key is in the known keys database, users must still agree to trust that key. Again, organisations may wish to keep their own white-list of allowed keys.
+The second option is probably easiest. Zero Install currently warns users if they run software signed with an unknown GPG key (we maintain a default database of known keys, but we do not have the resources to verify the owners of the keys). Again, organisations may wish to keep their own white-list of allowed keys.
 
 The first option can be made even harder if the developer has a second (non-networked) machine with the GPG key, although not all developers will have a spare machine for this purpose.
 

--- a/docs/developers/design.md
+++ b/docs/developers/design.md
@@ -71,17 +71,11 @@ Zero Install uses a SAT solver with conflict-driven learning to find the optimal
 
 # Interfaces and Implementations
 
-An interface
+An **interface** describes what something does (eg, "Simple text editor").
 
-describes what something does (eg, "Simple text editor").
+An **implementation** is something that does it (eg, Edit-1.9.6 or Edit-1.9.7).
 
-An implementation
-
-is something that does it (eg, Edit-1.9.6 or Edit-1.9.7).
-
-A feed file
-
-is a list of implementations of an interface.
+A **feed file** is a list of implementations of an interface.
 
 In Zero Install, interfaces are named by globally unique URIs (like web pages). Some examples of interfaces are:
 
@@ -141,7 +135,7 @@ If problems are found, it can instead be marked as **Buggy**, or **Insecure**. T
 
 You can use the **Preferred Stability** setting in the interface dialog to choose which versions to use. You can also change the stability rating of any implementation by clicking on it and choosing a new rating from the popup menu. User-set ratings are shown in capitals.
 
-As you make changes to the policy and ratings, the order of the implementations in the list will change. The version at the top is the one that the injector will actually use. In addition to the ratings about, you can set the rating to **Preferred**. Such versions always come first, unless they're not cached and you are in Off-line mode.
+As you make changes to the policy and ratings, the order of the implementations in the list will change. The version in bold is the one that 0install will actually use. In addition to the ratings about, you can set the rating to **Preferred**. Such versions always come first, unless they're not cached and you are in Off-line mode.
 
 Note: If you want to use the second item on the list because the first is buggy, for example, then it is better to mark the first version as buggy than to mark the second as preferred. This is because when a new version is available, you will want that to become the version at the top of the list, whereas a preferred version will always be first.
 

--- a/docs/developers/json-api.md
+++ b/docs/developers/json-api.md
@@ -105,7 +105,8 @@ Return a set of selections to run the given program. If `refresh` is `true`, 0in
 : A message to display if 0install uses its own GUI ("I need this because ...")
 
 `may_compile`
-: (0install >= 2.9; default `false`) Treat source implementations as potential binaries. If a source implementation is selected, it will be tagged with `requires-compilation="true"` to indicate this.
+: (0install >= 2.9; default `false`)
+: Treat source implementations as potential binaries. If a source implementation is selected, it will be tagged with `requires-compilation="true"` to indicate this.
 : Returns `["ok",{"stale":stale-flag}]` on success. If stale-flag is true, the selections are based on old information. Consider using `refresh` to check for updates.
 
 # Sample code

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -8,11 +8,11 @@ Frequently asked questions:
 
 What is it?
 
-: Zero Install is a way to run software without an explicit installation step. This is easier (_install and run_ becomes just _run_) and safer (installation doesn't happen as root).
+: Zero Install is a decentralised cross-distribution software installation system. Features include full support for shared libraries (with a SAT solver for dependency resolution), sharing between users, and integration with native platform package managers. It supports both binary and source packages, and works on Linux, OS X, Unix and Windows systems. It is fully Open Source.
 
 How many Zero Install packages are there?
 
-: The [public mirror site](http://roscidus.com/0mirror/) provides a list of feeds we know about. There are currently more than 500, although the quality varies.
+: The [public mirror site](http://roscidus.com/0mirror/) provides a list of feeds we know about. There are currently more than 2000, although the quality varies.
 
 What are "decentralised" installation systems, and why are they important?
 
@@ -96,7 +96,7 @@ What if something gets automatically removed from the cache while I'm up a mount
 
 : Currently, nothing is ever automatically removed from the cache. Users can choose the purging scheme that suits them. For users with broadband, that might mean removing anything that hasn't been accessed for a year. For users with dial-up and 80Gb disks, that probably means never ever removing anything.
 
-: You can click on the **Cache** button to view the cache and remove versions of programs you don't need anymore:
+: You can run `0install store manage` to view the cache and remove versions of programs you don't need anymore:
 
 : ![Uninstalling programs](img/screens/injector-cache.png)
 


### PR DESCRIPTION
- Don't introduce apps by comparing with the (long-deprecated) aliases.
- Remove timing comparison. It was from the old Python version. The OCaml version is much faster (and now dominated by the program's own start-up time rather than by the solver).
- Use the (newer) summary from the homepage for the FAQ too.
- Various formatting fixes.